### PR TITLE
Ensure nextschedule is not None

### DIFF
--- a/xontrib/schedule.py
+++ b/xontrib/schedule.py
@@ -39,6 +39,8 @@ class Scheduler:
                 nextschedule = _schedule.idle_seconds()
             except Exception:
                 nextschedule = Inf
+            if nextschedule is None:
+                nextschedule = Inf
 
             if nextsched == nextschedule == Inf:
                 self._delay(1)  # Finish init


### PR DESCRIPTION
More recent versions of schedule do not throw an exception when calling
'schedule.idle_seconds()'. Instead, they return None as necessary. This
results in an error when calling min().

Now, we always ensure we're comparing floats.